### PR TITLE
Add documentation for Improve Digital Bid Adapter's newly added support for MultiBid

### DIFF
--- a/dev-docs/bidders/improvedigital.md
+++ b/dev-docs/bidders/improvedigital.md
@@ -31,7 +31,6 @@ sidebarType: 1
 | `bidFloor`  | optional | Bid floor price | `0.01` | `float` |
 | `bidFloorCur`  | optional | Bid floor price currency. Supported values: USD (default), EUR, GBP, AUD, DKK, SEK, CZK, CHF, NOK | `'USD'` | `string` |
 | `extend`  | optional | See the [Extend mode section](#improvedigital-extend)  | `true` | `boolean` |
-| `rendererConfig`  | optional | Configuration object for JS renderer of the RAZR creatives. Provided by Improve Digital.  | `{ key1: value1 }` | `object` |
 
 ### Configuration
 
@@ -44,22 +43,6 @@ By default, the adapter sends Prebid ad unit sizes to Improve Digital's ad serve
 ```javascript
 pbjs.setConfig({
     improvedigital: { usePrebidSizes: false }
-});
-```
-
-<a name="improvedigital-renderer"></a>
-
-#### Renderer Config
-
-Global configuration for the special creative format renderer. Please use [rendererConfig bid param](#improvedigital-params) for ad slot specific configuration.
-
-```javascript
-pbjs.setConfig({
-    improvedigital: {
-        rendererConfig: {
-            // Global config object provided by Improve Digital
-        }
-    }
 });
 ```
 
@@ -78,6 +61,21 @@ pbjs.setConfig({
     improvedigital: {
         extend: true
     }
+});
+```
+
+<a name="improvedigital-multibid"></a>
+
+#### MultiBid
+
+Improve Digital supports Prebid's MultiBid feature. More on enabling MultiBid can be found here: [MultiBid](https://docs.prebid.org/dev-docs/modules/multibid.html). An example of how to enable MultiBid for Improve Digital:
+
+```javascript
+pbjs.setConfig({
+    multibid: [{
+        bidder: "improvedigital",
+        maxBids: 3,
+    }]
 });
 ```
 


### PR DESCRIPTION
Adds documentation for Improve Digital's Bid Adapter newly added support for MultiBid and removes a previously deprecated param and its example section.

## 🏷 Type of documentation

- [x] update bid adapter
- [x] new feature
- [x] new examples

## References

 - [Improve Digital Bid Adapter: Added support for MultiBid](https://github.com/prebid/Prebid.js/pull/12777) 